### PR TITLE
Adding some feature

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -24,6 +24,9 @@
     constructor: (options) ->
       @_options = $.extend({
         name: 'tour'
+        end: 'End tour'
+        next: 'Next &raquo;'
+        previous: '&laquo; Prev'
         afterSetState: (key, value) ->
         afterGetState: (key, value) ->
         onShow: (tour) ->
@@ -165,12 +168,12 @@
 
       nav = []
       if step.prev >= 0
-        nav.push "<a href='##{step.prev}' class='prev'>&laquo; Prev</a>"
+        nav.push "<a href='##{step.prev}' class='prev'>#{@_options.previous}</a>"
       if step.next >= 0
-        nav.push "<a href='##{step.next}' class='next'>Next &raquo;</a>"
+        nav.push "<a href='##{step.next}' class='next'>#{@_options.next}</a>"
       content += nav.join(" | ")
 
-      content += "<a href='#' class='pull-right end'>End Tour</a>"
+      content += "<a href='#' class='pull-right end'>#{@_options.end}</a>"
 
       $(step.element).popover({
         placement: step.placement

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -31,6 +31,9 @@
         var _this = this;
         this._options = $.extend({
           name: 'tour',
+          end: 'End tour',
+          next: 'Next &raquo;',
+          previous: '&laquo; Prev',
           afterSetState: function(key, value) {},
           afterGetState: function(key, value) {},
           onShow: function(tour) {},
@@ -183,13 +186,13 @@
         content = "" + step.content + "<br /><p>";
         nav = [];
         if (step.prev >= 0) {
-          nav.push("<a href='#" + step.prev + "' class='prev'>&laquo; Prev</a>");
+          nav.push("<a href='#" + step.prev + "' class='prev'>" + this._options.previous + "</a>");
         }
         if (step.next >= 0) {
-          nav.push("<a href='#" + step.next + "' class='next'>Next &raquo;</a>");
+          nav.push("<a href='#" + step.next + "' class='next'>" + this._options.next + "</a>");
         }
         content += nav.join(" | ");
-        content += "<a href='#' class='pull-right end'>End Tour</a>";
+        content += "<a href='#' class='pull-right end'>" + this._options.end + "</a>";
         $(step.element).popover({
           placement: step.placement,
           trigger: "manual",


### PR DESCRIPTION
##### Execute onShow before checking the visibility or existence of the element

The problem is quiet simple, it's not possible to give an hidden element to a step because we check first if the element exist or is visible.

If we want to render or show the element in the onShow function then we need the onShow function to be executed before.
##### Added a way to extend popover messages

Now the messages are in english it would be nice to give the possibility to extend the messages
