### PR TITLE
Fixing Tour for multi-tours in single page

### DIFF
--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -59,9 +59,6 @@
         this._onresize(function() {
           return _this.showStep(_this._current);
         });
-        this._onresize(function() {
-          return _this.showStep(_this._current);
-        });
       }
 
       Tour.prototype.setState = function(key, value) {


### PR DESCRIPTION
If more that one Tour is binding for one DOM element, twitter Popover does not use content of popover - it uses data-popover-\* attributes. Need to clear them before showing.
Also if more than one Tour is initing in one page - we have duplicates events
