### PR TITLE
Fix the tour re-appearing upon browser window resize

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -52,7 +52,7 @@
         @end()
 
       # Reshow popover on window resize using debounced resize
-      @_onresize(=> @showStep(@_current))
+      @_onresize(=> @showStep(@_current) unless @ended)
 
     setState: (key, value) ->
       $.cookie("#{@_options.name}_#{key}", value, { expires: 36500, path: '/' })

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -54,7 +54,9 @@
           return _this.end();
         });
         this._onresize(function() {
-          return _this.showStep(_this._current);
+          if (!_this.ended) {
+            return _this.showStep(_this._current);
+          }
         });
       }
 


### PR DESCRIPTION
Currently if you end the tour but then resize the window the tour appears again.
Pretty straightforward fix :)
