### PR TITLE
Fix Next, Prev and End links not working after restarting the tour

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -51,22 +51,6 @@
               if @_current > 0
                 @prev()
 
-
-      # Go to next step after click on element with class .next
-      $(document).on "click.bootstrap-tour", ".popover .next", (e) =>
-        e.preventDefault()
-        @next()
-
-      # Go to previous step after click on element with class .prev
-      $(document).on "click.bootstrap-tour", ".popover .prev", (e) =>
-        e.preventDefault()
-        @prev()
-
-      # End tour after click on element with class .end
-      $(document).on "click.bootstrap-tour", ".popover .end", (e) =>
-        e.preventDefault()
-        @end()
-
       # Reshow popover on window resize using debounced resize
       @_onresize(=> @showStep(@_current) unless @ended)
 
@@ -99,6 +83,21 @@
 
     # Start tour from current step
     start: (force = false) ->
+      # Go to next step after click on element with class .next
+      $(document).on "click.bootstrap-tour", ".popover .next", (e) =>
+        e.preventDefault()
+        @next()
+
+      # Go to previous step after click on element with class .prev
+      $(document).on "click.bootstrap-tour", ".popover .prev", (e) =>
+        e.preventDefault()
+        @prev()
+
+      # End tour after click on element with class .end
+      $(document).on "click.bootstrap-tour", ".popover .end", (e) =>
+        e.preventDefault()
+        @end()
+      
       if force || ! @ended()
         @showStep(@_current)
 

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -64,18 +64,6 @@
             }
           });
         }
-        $(document).on("click.bootstrap-tour", ".popover .next", function(e) {
-          e.preventDefault();
-          return _this.next();
-        });
-        $(document).on("click.bootstrap-tour", ".popover .prev", function(e) {
-          e.preventDefault();
-          return _this.prev();
-        });
-        $(document).on("click.bootstrap-tour", ".popover .end", function(e) {
-          e.preventDefault();
-          return _this.end();
-        });
         this._onresize(function() {
           if (!_this.ended) {
             return _this.showStep(_this._current);
@@ -119,9 +107,22 @@
       };
 
       Tour.prototype.start = function(force) {
+        var _this = this;
         if (force == null) {
           force = false;
         }
+        $(document).on("click.bootstrap-tour", ".popover .next", function(e) {
+          e.preventDefault();
+          return _this.next();
+        });
+        $(document).on("click.bootstrap-tour", ".popover .prev", function(e) {
+          e.preventDefault();
+          return _this.prev();
+        });
+        $(document).on("click.bootstrap-tour", ".popover .end", function(e) {
+          e.preventDefault();
+          return _this.end();
+        });
         if (force || !this.ended()) {
           return this.showStep(this._current);
         }

--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
         <h1 id="reflex-mode">Bootstrap Tour</h1>
         <p class="lead">Quick and easy way to build your product tours with Twitter Bootstrap Popovers.</p>
         <p>Note: This library does not depend on the full Bootstrap package. The only dependencies are the tooltip and popover files.</p>
+        <a href="#" class="restart">Restart tour</a>
       </header>
 
       <div class="row">


### PR DESCRIPTION
Currently, the event handlers to Prev, Next and End links are attached inside the constructor. When the tour is ended however, the event handlers are removed. After restarting the tour, event handlers are not re-attached and thus the links will not work.

I have moved attaching the event handlers to the start() method so the event handlers are attached every time the tour is started. Since we are already removeing event handlers when the tour ends, there should be no problems with multiple event handlers remaining around for the same event
