### PR TITLE
To handle several tours on one page the click bindings need to be removed

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -89,7 +89,7 @@
         @next()
 
       # Go to previous step after click on element with class .prev
-      $(document).off("click.bootstrap-tour",".popover .pref").on "click.bootstrap-tour", ".popover .prev", (e) =>
+      $(document).off("click.bootstrap-tour",".popover .prev").on "click.bootstrap-tour", ".popover .prev", (e) =>
         e.preventDefault()
         @prev()
 
@@ -239,8 +239,8 @@
     _onresize: (cb, timeout) ->
       $(window).resize ->
         clearTimeout(timeout)
-        timeout = setTimeout(cb, 100)		
-	
+        timeout = setTimeout(cb, 100)
+
   window.Tour = Tour
 
 )(jQuery, window)


### PR DESCRIPTION
To handle several tours on one page the click bindings need to be removed before new ones are added. If this does not happen than the first tour that was opened will reopen during the second tour.
