### PR TITLE
Allow multiple popovers on the same element

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -213,7 +213,7 @@
 
       content += "<a href='#' class='pull-right end'>#{options.labels.end}</a>"
 
-      $(step.element).popover({
+      $(step.element).popover('destroy').popover({
         placement: step.placement
         trigger: "manual"
         title: step.title

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -239,7 +239,7 @@
         }
         content += nav.join(" | ");
         content += "<a href='#' class='pull-right end'>" + options.labels.end + "</a>";
-        $(step.element).popover({
+        $(step.element).popover('destroy').popover({
           placement: step.placement,
           trigger: "manual",
           title: step.title,


### PR DESCRIPTION
While trying to bind multiple popovers on the same element I recognized, that the first popover created will allways be displayed. To fix this, one could call .popover('destroy') before creating a new popover.
