### PR TITLE
Fixed when using null in LocalStorage

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -56,6 +56,8 @@
     getState: (key) ->
       if this._options.useLocalStorage
         value = window.localStorage.getItem("#{@_options.name}_#{key}")
+        if value == 'null'
+          value = null
       else
         value = $.cookie("#{@_options.name}_#{key}")
       @_options.afterGetState(key, value)

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -71,6 +71,9 @@
         var value;
         if (this._options.useLocalStorage) {
           value = window.localStorage.getItem("" + this._options.name + "_" + key);
+          if (value === 'null') {
+            value = null;
+          }
         } else {
           value = $.cookie("" + this._options.name + "_" + key);
         }


### PR DESCRIPTION
When using getState in localStorage, the value is a string 'null', so when we have the tour_end value stored the ended method is always true, even when is null. This pull request fix it.

```
  Tour.prototype.ended = function() {
    //always true because the value is the string 'null'
    return !!this.getState("end");  
  };
```
