### PR TITLE
Add an option to set a stepId that will be used on the step's popover div

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -30,6 +30,7 @@
           prev: '&laquo; Prev'
         }
         keyboard: true,
+        allowState: true,
         useLocalStorage: false,
         afterSetState: (key, value) ->
         afterGetState: (key, value) ->
@@ -47,6 +48,8 @@
       @_onresize(=> @showStep(@_current) unless @ended)
 
     setState: (key, value) ->
+      if !this._options.allowState
+        return
       if this._options.useLocalStorage
         window.localStorage.setItem("#{@_options.name}_#{key}", value)
       else
@@ -54,6 +57,8 @@
       @_options.afterSetState(key, value)
 
     getState: (key) ->
+      if (!this._options.allowState)
+        return
       if this._options.useLocalStorage
         value = window.localStorage.getItem("#{@_options.name}_#{key}")
       else

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -37,6 +37,7 @@
             prev: '&laquo; Prev'
           },
           keyboard: true,
+          allowState: true,
           useLocalStorage: false,
           afterSetState: function(key, value) {},
           afterGetState: function(key, value) {},
@@ -56,6 +57,9 @@
       }
 
       Tour.prototype.setState = function(key, value) {
+        if (!this._options.allowState) {
+          return;
+        }
         if (this._options.useLocalStorage) {
           window.localStorage.setItem("" + this._options.name + "_" + key, value);
         } else {
@@ -69,6 +73,9 @@
 
       Tour.prototype.getState = function(key) {
         var value;
+        if (!this._options.allowState) {
+          return;
+        }
         if (this._options.useLocalStorage) {
           value = window.localStorage.getItem("" + this._options.name + "_" + key);
         } else {


### PR DESCRIPTION
This very small changes add an option on the step : 

```
tour.addStep({
  element: "",
  stepId: "myPopoverId"
  title: "", /* title of the popover */
  content: "" /* content of the popover */
});
```

The `stepId`, if provided, is used as the id of the popover div element, allowing to apply easily  any custom style.
