### PR TITLE
Modified step.path to allow for URLs with query parameters

### DIFF
--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -172,7 +172,9 @@
           return;
         }
         this.setCurrentStep(i);
-        if (step.path !== "" && document.location.pathname !== step.path && document.location.pathname.replace(/^.*[\\\/]/, '') !== step.path) {
+        queryIndex = step.path.indexOf("?");
+        queryParamsRemoved = (queryIndex > 0) ? step.path.substring(0,queryIndex) : step.path;
+        if (step.path !== "" && document.location.pathname !== queryParamsRemoved && document.location.pathname.replace(/^.*[\\\/]/, '') !== step.path) {
           document.location.href = step.path;
           return;
         }


### PR DESCRIPTION
Modified multi-page tours to allow for `path` attributes with query parameters.  For example, the following is now valid:

<code>
tour.addStep({
    element: '#something',
    position: 'top',
    path: '/search?demo=true',
    title: 'Searching Demo',
    content: 'I filled out the form for my user!'
});
</code>

This is especially useful when the tour should guide a user through form input and wants to control exactly what parameters are submitted while allowing the user to simply keep clicking 'Next'.   Also useful for displaying demo version of certain pages when a tour is in progress.
