### PR TITLE
Executes onShow promises before showing next step.

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,18 +153,22 @@ var tour = new Tour({
 });
 </pre>
           <h4><code>onStart</code></h4>
-          <p>Function to execute when the tour starts.</p>
+          <p>Function to execute when the tour starts. If
+          the function returns a Promise object (including jQuery.Deferred), the first step won't
+          be shown until the Promise is resolved. </p>
 
           <h4><code>onEnd</code></h4>
           <p>Function to execute when the tour ends.</p>
 
           <h4><code>onShow</code></h4>
           <p>Function to execute right before each step is shown. If
-          the function returns a Promise object, the next step won't
+          the function returns a Promise object (including jQuery.Deferred), the next step won't
           be shown until the Promise is resolved. </p>
 
           <h4><code>onHide</code></h4>
-          <p>Function to execute right before each step is hidden.</p>
+          <p>Function to execute right before each step is hidden. If
+          the function returns a Promise object (including jQuery.Deferred), the current step won't
+          be hidden until the Promise is resolved. </p>
 
           <h3>Step Options</h3>
           <p>Default options:</p>

--- a/tests/tests.coffee
+++ b/tests/tests.coffee
@@ -320,7 +320,28 @@ test "Tour shouldn't move to the next state until the onShow promise is resolved
   @tour.addStep({element: $("<div></div>").appendTo("#qunit-fixture")})   
   @tour.addStep({element: $("<div></div>").appendTo("#qunit-fixture"), onShow: -> return deferred})
   @tour.start()
-  @tour.showNextStep()
+  @tour.next()
   strictEqual(@tour._current, 0, "tour shows old state until resolving of onShow promise") 
   deferred.resolve()
   strictEqual(@tour._current, 1, "tour shows new state after resolving onShow promise")
+
+test "Tour shouldn't hide popover until the onHide promise is resolved", ->
+  @tour = new Tour()
+  deferred = $.Deferred()
+  @tour.addStep({element: $("<div></div>").appendTo("#qunit-fixture"), onHide: -> return deferred})   
+  @tour.addStep({element: $("<div></div>").appendTo("#qunit-fixture")})
+  @tour.start()
+  @tour.next()
+  strictEqual(@tour._current, 0, "tour shows old state until resolving of onHide promise")
+  deferred.resolve()
+  strictEqual(@tour._current, 1, "tour shows new state after resolving onShow promise")
+
+test "Tour shouldn't start until the onStart promise is resolved", ->
+  deferred = $.Deferred()
+  @tour = new Tour({onStart: -> return deferred})
+  @tour.addStep({element: $("<div></div>").appendTo("#qunit-fixture")})
+  @tour.start()
+  strictEqual($(".popover").length, 0, "Tour does not start before onStart promise is resolved")
+  deferred.resolve()
+  strictEqual($(".popover").length, 1, "Tour starts after onStart promise is resolved")
+

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -458,10 +458,47 @@
       }
     });
     this.tour.start();
-    this.tour.showNextStep();
+    this.tour.next();
     strictEqual(this.tour._current, 0, "tour shows old state until resolving of onShow promise");
     deferred.resolve();
     return strictEqual(this.tour._current, 1, "tour shows new state after resolving onShow promise");
+  });
+
+  test("Tour shouldn't hide popover until the onHide promise is resolved", function() {
+    var deferred;
+    this.tour = new Tour();
+    deferred = $.Deferred();
+    this.tour.addStep({
+      element: $("<div></div>").appendTo("#qunit-fixture"),
+      onHide: function() {
+        return deferred;
+      }
+    });
+    this.tour.addStep({
+      element: $("<div></div>").appendTo("#qunit-fixture")
+    });
+    this.tour.start();
+    this.tour.next();
+    strictEqual(this.tour._current, 0, "tour shows old state until resolving of onHide promise");
+    deferred.resolve();
+    return strictEqual(this.tour._current, 1, "tour shows new state after resolving onShow promise");
+  });
+
+  test("Tour shouldn't start until the onStart promise is resolved", function() {
+    var deferred;
+    deferred = $.Deferred();
+    this.tour = new Tour({
+      onStart: function() {
+        return deferred;
+      }
+    });
+    this.tour.addStep({
+      element: $("<div></div>").appendTo("#qunit-fixture")
+    });
+    this.tour.start();
+    strictEqual($(".popover").length, 0, "Tour does not start before onStart promise is resolved");
+    deferred.resolve();
+    return strictEqual($(".popover").length, 1, "Tour starts after onStart promise is resolved");
   });
 
 }).call(this);


### PR DESCRIPTION
I needed the ability to perform an animation before the next tour item was shown, so I added the capability to execute a promise object on onShow. The motivating example is with a collapsible navbar in bootstrap:

``` javascript
            tour.addStep({
                element: ".btn-navbar",
                title: "Navigation Menu",
                content: "This button shows the navigation menu",
                placement: "bottom",
                onShow: function(){ return $(".nav-collapse").collapse('show').promise();}
            });
        }
```
