### PR TITLE
Do not scroll into view when 'top' and/or 'left' is 0

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -241,7 +241,7 @@
     # Scroll to the popup if it is not in the viewport
     _scrollIntoView: (tip) ->
       tipRect = tip.get(0).getBoundingClientRect()
-      unless tipRect.top > 0 && tipRect.bottom < $(window).height() && tipRect.left > 0 && tipRect.right < $(window).width()
+      unless tipRect.top >= 0 && tipRect.bottom < $(window).height() && tipRect.left >= 0 && tipRect.right < $(window).width()
         tip.get(0).scrollIntoView(true)
 
     # Debounced window resize

--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -275,7 +275,7 @@
       Tour.prototype._scrollIntoView = function(tip) {
         var tipRect;
         tipRect = tip.get(0).getBoundingClientRect();
-        if (!(tipRect.top > 0 && tipRect.bottom < $(window).height() && tipRect.left > 0 && tipRect.right < $(window).width())) {
+        if (!(tipRect.top >= 0 && tipRect.bottom < $(window).height() && tipRect.left >= 0 && tipRect.right < $(window).width())) {
           return tip.get(0).scrollIntoView(true);
         }
       };


### PR DESCRIPTION
There is no need to scroll when tipRect.top or tipRect.left is 0.
