### PR TITLE
Fix stackover flow

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -119,6 +119,7 @@
     end: ->
       @hideStep(@_current)
       $(document).off "click.bootstrap-tour"
+      $(document).off "keyup.bootstrap-tour"
       @setState("end", "yes")
 
       @_options.onEnd(@) if @_options.onEnd?


### PR DESCRIPTION
In Chromium version 24, when End Tour is clicked, I get an error in the web console saying:

```SyntaxError: Invalid regular expression: /(^|.)bootstrap-tour(.|$)/: Stack overflow

```

This pull request fixes it as the event name should be explicit in both `.on()` and `.off()`
```
