### PR TITLE
add a custom class name to your steps

### DIFF
--- a/bootstrap-tour.coffee
+++ b/bootstrap-tour.coffee
@@ -31,6 +31,7 @@
         }
         keyboard: true,
         useLocalStorage: false,
+        stepClass : '',
         afterSetState: (key, value) ->
         afterGetState: (key, value) ->
         onStart: (tour) ->
@@ -224,6 +225,7 @@
       }).popover("show")
 
       tip = $(step.element).data("popover").tip()
+      $(tip).addClass(options.stepClass)
       @_reposition(tip)
       @_scrollIntoView(tip)
 


### PR DESCRIPTION
adding a new property called "stepClass", which allows a user to set a series of custom classes to the pop-over.
currently only available as part of the tour setup, and can not be over-written by each individual step.
