### PR TITLE
Allow configurable base path

### DIFF
--- a/bootstrap-tour.js
+++ b/bootstrap-tour.js
@@ -40,6 +40,7 @@
           debug: false,
           backdrop: false,
           redirect: true,
+          basePath: '',
           afterSetState: function(key, value) {},
           afterGetState: function(key, value) {},
           afterRemoveState: function(key) {},
@@ -236,7 +237,7 @@
           var current_path, path;
 
           _this.setCurrentStep(i);
-          path = typeof step.path === "function" ? step.path.call() : step.path;
+          path = typeof step.path === "function" ? step.path.call() : this._options.basePath + step.path;
           current_path = [document.location.pathname, document.location.hash].join('');
           if (_this._isRedirect(path, current_path)) {
             _this._redirect(step, path);


### PR DESCRIPTION
We have a need in order to re-use the tours on several different environments where base path might differ, eg. localhost/test-site/ vs. localhost/

Although I am not a real JS developer I gave it a try ;) Extended the config to have the basePath defaulting to empty.
