### PR TITLE
Fix: typo prevented reflex .click event removal in hideStep

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -178,7 +178,7 @@
 
       hideStepHelper = (e) =>
         $element = $(step.element).popover("hide")
-        $element.css("cursor", "").off "click.boostrap-tour" if step.reflex
+        $element.css("cursor", "").off "click.bootstrap-tour" if step.reflex
         @_hideBackdrop() if step.backdrop
 
         step.onHidden(@) if step.onHidden?


### PR DESCRIPTION
Create a tour with two adjacent steps on the same page, at least one of which has reflex: true.  Switch back and forth between the steps n times.  Click a reflex-y element.  Expectation: you go forward 1 step.  Result: you go forward n steps.  This fixes that.
