### PR TITLE
Expand the reflex capabilities: allow for a jQuery selector [with docs]

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -484,9 +484,11 @@
                         </tr>
                         <tr>
                             <td>reflex</td>
-                            <td>Boolean</td>
-                            <td>Enable the reflex mode: you can click on the element for
-                            continue the tour.</td>
+                            <td>Boolean|String (jQuery selector)</td>
+                            <td>If <code class="language-javascript">true</code>, enable the reflex
+                            mode: you can click on the element to continue the tour.  If you give a
+                            selector, instead you can click any selected element to continue the
+                            tour</td>
                             <td><code class="language-javascript">false</code></td>
                         </tr>
                         <tr>

--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -178,7 +178,8 @@
 
       hideStepHelper = (e) =>
         $element = $(step.element).popover("hide")
-        $element.css("cursor", "").off "click.bootstrap-tour" if step.reflex
+        selector = if typeof step.reflex is 'string' then step.reflex else step.element
+        $(selector).css("cursor", "").off "click.bootstrap-tour" if step.reflex
         @_hideBackdrop() if step.backdrop
 
         step.onHidden(@) if step.onHidden?
@@ -288,7 +289,8 @@
       if step.options
         $.extend options, step.options
       if step.reflex
-        $(step.element).css("cursor", "pointer").on "click.bootstrap-tour", (e) =>
+        selector = if typeof step.reflex is 'string' then step.reflex else step.element
+        $(selector).css("cursor", "pointer").on "click.bootstrap-tour", (e) =>
           @next()
 
       rendered = @_renderNavigation(step, i, options)


### PR DESCRIPTION
Give arbitrary elements selectable with a jQuery selector, not just step.element, an advance-to-next-step click handler.
