### PR TITLE
Switched the scrolling behavior to center the tooltip vertically

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -353,8 +353,7 @@
 
     # Scroll to the popup if it is not in the viewport
     _scrollIntoView: (tip) ->
-      windowHalf = $(window).height() / 2
-      tipOffset = Math.ceil(tip.offset().top - windowHalf)
+      tipOffset = Math.ceil(tip.offset().top - ($(window).height() / 2))
       $("html, body").stop().animate({scrollTop: tipOffset})
 
     # Debounced window resize


### PR DESCRIPTION
Changed the scroll behavior to center the popover in the browser window, to minimize issues with popover placement and/or a higher z-index persistent navbar.

See issues #114 and #125
