### PR TITLE
Add backward compatibility with bootstrap 2.3.2

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "version": "0.5.1",
   "main": ["./build/js/bootstrap-tour.js", "./build/css/bootstrap-tour.css"],
   "dependencies": {
-    "bootstrap": "3.0.0",
+    "bootstrap": ">=2.3.2",
     "jquery": "~1.8.0"
   }
 }


### PR DESCRIPTION
1. Add backward compatibility with bootstrap 2.3.2
2. What about JQuery version can bootstrap-tour work with 1.10.x?
