### PR TITLE
scrollIntoView does not work in firefox

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -447,11 +447,13 @@
       scrollTop = Math.max(0, offsetTop - (windowHeight / 2))
 
       @_debug "Scroll into view. ScrollTop: #{scrollTop}. Element offset: #{offsetTop}. Window height: #{windowHeight}."
-      $("body").stop().animate
+      counter = 0
+      $("body,html").stop(true,true).animate
         scrollTop: Math.ceil(scrollTop),
         =>
-          callback()
-          @_debug "Scroll into view. Animation end element offset: #{$element.offset().top}. Window height: #{$window.height()}."
+          if ++counter == 2
+            callback()
+            @_debug "Scroll into view. Animation end element offset: #{$element.offset().top}. Window height: #{$window.height()}."
 
     # Debounced window resize
     _onResize: (callback, timeout) ->


### PR DESCRIPTION
solution is to launch the animation on both body and html elements
(solution found there http://stackoverflow.com/questions/8149155/animate-scrolltop-not-working-in-firefox)

After this fix, the callback was called twice, so I added a counter to limit to one call on the callback function.
