### PR TITLE
Fix invalid javascript on frontpage example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -55,7 +55,7 @@ slug: home
     <h3>Setup your tour:</h3>
 {% highlight javascript %}
 // Instance the tour
-var tour = new Tour(
+var tour = new Tour({
   steps: [
   {
     element: "#my-element",
@@ -67,7 +67,7 @@ var tour = new Tour(
     title: "Title of my step",
     content: "Content of my step"
   }
-]);
+]});
 
 // Initialize the tour
 tour.init();


### PR DESCRIPTION
I'm not sure if the alignment is ideal, so happy to change that, but the most
prominent (and simplest) example that's on the front page is currently broken
without this patch.
