### PR TITLE
fix placement relative to tall elements

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -442,7 +442,7 @@
     _replaceArrow: ($tip, delta, dimension, position)->
       $tip
         .find(".arrow")
-        .css(position, if delta then Math.min(0, Math.max(50, 50 * (1 - delta / dimension))) + "%" else "")
+        .css(position, if delta then Math.max(0, Math.min(50, 50 * (1 - delta / dimension))) + "%" else "")
 
     # Scroll to the popup if it is not in the viewport
     _scrollIntoView: (element, callback) ->


### PR DESCRIPTION
If the element is very tall, prevent the tooltip from being pushed offscreen; make sure that the placement of the arrow cannot escape the range of 0-50% of tooltip height or width
