### PR TITLE
Check working step is still the current step

### DIFF
--- a/build/js/bootstrap-tour.js
+++ b/build/js/bootstrap-tour.js
@@ -305,6 +305,9 @@
             _this._showBackdrop(!_this._isOrphan(step) ? step.element : void 0);
           }
           _this._scrollIntoView(step.element, function() {
+            if (_this.getCurrentStep() !== i) {
+              return;
+            }
             if ((step.element != null) && step.backdrop) {
               _this._showOverlayElement(step.element);
             }


### PR DESCRIPTION
One can end up with multiple stalled popovers all over because scrollIntoView can some times take a while to end (and current step could have changed by the time), so do not assume the current step is still the same and do not show overlay or do things if the current step has changed since scrollIntoView started.
