### PR TITLE
handle window.localStorage being unavailable

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -3,12 +3,17 @@
 
   class Tour
     constructor: (options) ->
+      try
+        storage = window.localStorage
+      catch
+        # localStorage may be unavailable due to security settings
+        storage = false
       @_options = $.extend
         name: "tour"
         steps: []
         container: "body"
         keyboard: true
-        storage: window.localStorage
+        storage: storage
         debug: false
         backdrop: false
         redirect: true


### PR DESCRIPTION
Some security settings (Firefox 'always ask' cookie setting) may result in accessing window.localStorage raising SecurityError.

Setting this as the default, even if unused, makes it impossible to instantiate a Tour in such a context.

This is related to #236, where the proposed solution doesn't work because

``` javascript
tour = Tour({storage : false});
```

will still raise a SecurityError when the unused default is populated.

This changes the default to `false` if accessing localStorage fails.
