### PR TITLE
IE backdrop fixes

### DIFF
--- a/src/less/bootstrap-tour.less
+++ b/src/less/bootstrap-tour.less
@@ -7,6 +7,7 @@
   z-index: 1100;
   background-color: #000;
   opacity: 0.8;
+  -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=80)";
 }
 
 .tour-step-backdrop {
@@ -16,7 +17,7 @@
 }
 
 .tour-step-background {
-  position: absolute;
+  position: absolute !important;
   z-index: 1100;
   background: inherit;
   border-radius: 6px;


### PR DESCRIPTION
When backdrop was used on IE, a white background would appear at the bottom of the page. I was able to reproduce this issue in IE8, IE10 and IE11.

In IE8 the backdrop background color was black without any opacity.

These fixes were tested in IE8, IE10, IE11 and Chrome, everything seemed to be functioning properly in all four browsers.
