### PR TITLE
Fix typo in "The How-to" setting up the tour

### DIFF
--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -55,7 +55,7 @@ slug: home
     <h3>Setup your tour:</h3>
 {% highlight javascript %}
 // Instance the tour
-var tour = new Tour(
+var tour = new Tour({
   steps: [
   {
     element: "#my-element",
@@ -67,7 +67,7 @@ var tour = new Tour(
     title: "Title of my step",
     content: "Content of my step"
   }
-]);
+]});
 
 // Initialize the tour
 tour.init();


### PR DESCRIPTION
The tour setup requires steps to be in the configuration object - but the {} are currently missing in the "How-to" from the Bootstrap Tour homepage.
