### PR TITLE
Utilized local var to prevent double search

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -447,12 +447,13 @@
       $navigation = $template.find '.popover-navigation'
       $prev = $navigation.find '[data-role="prev"]'
       $next = $navigation.find '[data-role="next"]'
+      $resume = $navigation.find '[data-role="pause-resume"]'
 
       $template.addClass 'orphan' if @_isOrphan step
       $template.addClass "tour-#{@_options.name} tour-#{@_options.name}-#{i}"
-      $navigation.find('[data-role="prev"]').addClass('disabled') if step.prev < 0
-      $navigation.find('[data-role="next"]').addClass('disabled') if step.next < 0
-      $navigation.find('[data-role="pause-resume"]').remove() unless step.duration
+      $prev.addClass('disabled') if step.prev < 0
+      $next.addClass('disabled') if step.next < 0
+      $resume.remove() unless step.duration
       $template.clone().wrap('<div>').parent().html()
 
     _reflexEvent: (reflex) ->


### PR DESCRIPTION
`$navigation.find '[data-role="prev"]'` was being run twice.

Once saved to the local variables `$prev` and `$next`, and again to actually use the elements because the local variables were never used.  This change makes use of them and removes the duplicate search.

The unused code was introduced in this revision [4b5dfb4](https://github.com/sorich87/bootstrap-tour/commit/4b5dfb40417621f95aef102f5c49b806f3152133), which doesn't look to have intentionally made those decisions for some reason.