### PR TITLE
Update multipage section documentation

### DIFF
--- a/src/docs/api.html
+++ b/src/docs/api.html
@@ -646,7 +646,7 @@ tour.addStep({
             </h2>
         </div>
         <p>Bootstrap Tour can be used to create tours that span multiple pages. If you have URLs for each page that have
-            unique paths, you can easily create a tour like so:
+            unique paths, and the dependencies are loaded on each page, you can easily create a tour like so:
         </p>
 {% highlight javascript %}
 var tour = new Tour({


### PR DESCRIPTION
Added a quick reminder in the multipage documentation that the bootstrap-tour dependencies need to be loaded on the pages you are trying to traverse to 