### PR TITLE
Make the package.json valid

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,12 +70,7 @@
   "engines": {
     "node": ">= 0.8.0"
   },
-  "main": [
-    "./build/js/bootstrap-tour.js",
-    "./build/js/bootstrap-tour-standalone.js",
-    "./build/css/bootstrap-tour.css",
-    "./build/css/bootstrap-tour-standalone.css"
-  ],
+  "main": "./build/js/bootstrap-tour.js",
   "scripts": {
     "build": "gulp dist",
     "test": "gulp test"


### PR DESCRIPTION
Package.json only allows one main file to be specified, which must be the main (js) entry point of the module. 
Having an array here breaks tooling that assumes the package.json to be valid (which most tooling does).

Source:
[1] https://docs.npmjs.com/files/package.json
[2] http://package-json-validator.com/