### PR TITLE
Buildable on windows

### DIFF
--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -131,7 +131,7 @@ gulp.task 'test-go', ['test-coffee'], (done) ->
 
 # docs
 gulp.task 'docs-build', ['coffee', 'less'], (done) ->
-  spawn 'jekyll', ['build']
+  spawn `(process.platform === "win32" ? "jekyll.bat" : "jekyll")`, ['build']
     .on 'close', done
 
 gulp.task 'docs-copy', ['docs-build'], ->

--- a/gulpfile.coffee
+++ b/gulpfile.coffee
@@ -131,7 +131,7 @@ gulp.task 'test-go', ['test-coffee'], (done) ->
 
 # docs
 gulp.task 'docs-build', ['coffee', 'less'], (done) ->
-  spawn `(process.platform === "win32" ? "jekyll.bat" : "jekyll")`, ['build']
+  spawn `(process.platform === 'win32' ? 'jekyll.bat' : 'jekyll')`, ['build']
     .on 'close', done
 
 gulp.task 'docs-copy', ['docs-build'], ->


### PR DESCRIPTION
The build now checks the platform and uses 'jekyll.bat' on windows otherwise the original 'jekyll' command is called. 