### PR TITLE
Added instruction for forcefully starting the tour every time

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,6 +125,14 @@ ga('send', 'pageview');
 <span class="c1">// Start the tour</span>
 <span class="nx">tour</span><span class="p">.</span><span class="nx">start</span><span class="p">();</span></code></pre></div>
     <p>Do you want to do more? <a href="api">Read the full documentation.</a></p>
+    <p>Please note: By default, this will run the tour only once in your browser. So if you want to see it every time for debugging purpose, please use:</br></br>
+      <code>
+        <span class="c1">// Force initialize the tour</span> </br>
+        <span class="nx">tour</span><span class="p">.</span><span class="nx">init</span><span class="p">(true);</span> </br> </br>
+        <span class="c1">// Force start the tour</span> </br>
+        <span class="nx">tour</span><span class="p">.</span><span class="nx">start</span><span class="p">(true);</span>
+      </code>
+    </p>
   </div>
 </section>
 <section id="contributing">


### PR DESCRIPTION
As a developer, I have faced this issue first hand. I wasn't able to see the popups no matter what I do!

I think for debugging purpose, developer will need to see the tour every time on page load. Setting this both params to `true` does the job.