### PR TITLE
Consider the element visibility before displaying the popup

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -287,7 +287,7 @@
         @_showBackdrop(step) if step.backdrop
 
         showPopoverAndOverlay = =>
-          return if @getCurrentStep() isnt i
+          return if @getCurrentStep() isnt i or @ended()
 
           @_showOverlayElement step if step.element? and step.backdrop
           @_showPopover step, i

--- a/src/docs/assets/js/bootstrap-tour.js
+++ b/src/docs/assets/js/bootstrap-tour.js
@@ -328,7 +328,7 @@
             _this._showBackdrop(step);
           }
           showPopoverAndOverlay = function() {
-            if (_this.getCurrentStep() !== i) {
+            if (_this.getCurrentStep() !== i || !$(step.element).is(':visible')) {
               return;
             }
             if ((step.element != null) && step.backdrop) {


### PR DESCRIPTION
Hi,


I am submitting the compiled JavaScript file because on my windows machine the cofeescript somehow crash with the error: https://github.com/AXElements/accessibility_core/issues/15. 

However, you can use the following scenario to reproduce the issue:
- when the content is rendered, the steps are refreshed and by tour contains at least one step added
- the current step has autoscroll enabled and the step is scheduled to be displayed with a little delay in
            _this._scrollIntoView(step.element, showPopoverAndOverlay);
- the view is closed and the tour is closed. The ended() method would return true, but no one checks and when the delay is finieshed, the showPopoverAndOverlay is executed and the tour is displayed on an invalid element.

Best Regards,
Daniel