### PR TITLE
Check if the tour is ended when this is shown

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -287,7 +287,7 @@
         @_showBackdrop(step) if step.backdrop
 
         showPopoverAndOverlay = =>
-          return if @getCurrentStep() isnt i
+          return if @getCurrentStep() isnt i or @ended()
 
           @_showOverlayElement step if step.element? and step.backdrop
           @_showPopover step, i


### PR DESCRIPTION
The tour is shown even before this is closed. The steps to reproduce the issue are:
- refresh the steps of the tour. The first step must have autoscroll enabled
- the showStep is called on a step that has the autoscroll enabled. Because of that the showPopupAndOverlay is scheduled later
- the tooltip is distroyed and the callback is still executed later 
