### PR TITLE
Fix typo in docs

### DIFF
--- a/src/docs/index.html
+++ b/src/docs/index.html
@@ -36,7 +36,7 @@ slug: home
       <h2>The How-to <small>It's simple!</small></h2>
     </div>
     <h3>Add the dependencies</h3>
-    <p>If you are using Bootstrap, include <code>bootstrap-tour.min.css</code> and <code>bootstrap-tour.min.js</code>:</p>
+    <p>If you are using Bootstrap, include <code>bootstrap.min.css</code> and <code>bootstrap-tour.min.js</code>:</p>
 {% highlight html %}
 <link href="bootstrap.min.css" rel="stylesheet">
 <link href="bootstrap-tour.min.css" rel="stylesheet">


### PR DESCRIPTION
Previous docs said to include `bootstrap-tour.min.js` twice instead of `bootstrap.min.js` and `bootstrap-tour.min.js`