### PR TITLE
Use $el.position instead of $el.offset

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -677,7 +677,7 @@
       elementData =
         width: $element.innerWidth()
         height: $element.innerHeight()
-        offset: $element.offset()
+        offset: $element.position()
 
       elementData = @_applyBackdropPadding step.backdropPadding, elementData if step.backdropPadding
       @backdrop


### PR DESCRIPTION
When backdrop element is in a relative div,
$el.offset positions the backdrop incorrectly