### PR TITLE
Put Clearfix on popover navigation

### DIFF
--- a/src/less/bootstrap-tour.less
+++ b/src/less/bootstrap-tour.less
@@ -32,6 +32,7 @@
 
   .popover-navigation {
     padding: 9px 14px;
+    overflow: hidden;
 
     *[data-role="end"] {
       float: right;


### PR DESCRIPTION
In the case you customize the template (like I did) with just 1 button at right (I did with just a next button), you need an clearfix on popover-navigation to keep the height of the float button