### PR TITLE
Add support for the AMD loader

### DIFF
--- a/src/coffee/bootstrap-tour.coffee
+++ b/src/coffee/bootstrap-tour.coffee
@@ -1,4 +1,4 @@
-(($, window) ->
+factory = (($) ->
   document = window.document
 
   class Tour
@@ -762,6 +762,12 @@
         return true
 
       return obj1 is obj2
-  window.Tour = Tour
+  Tour
+)
 
-) jQuery, window
+if typeof define is 'function' and define.amd?
+  define(['jquery'], factory)
+else if typeof exports is 'object'
+  module.exports = factory(jQuery)
+else
+  window.Tour = factory(jQuery)


### PR DESCRIPTION
I'd quite like to use this library in a project I work on (moodle/moodle), however JS in Moodle is loaded via AMD/requireJS.

This patch adds support for requireJS by modifying the way in which it is loaded.

I'm afraid I don't quite know where to start with adding appropriate tests for this, but existing tests continue to pass.
I have also only submitted the coffee file and not the built files. Hope this is correct.