### PR TITLE
Fix for issue #588

### DIFF
--- a/build/js/bootstrap-tour-standalone.js
+++ b/build/js/bootstrap-tour-standalone.js
@@ -1367,7 +1367,10 @@
     };
 
     Tour.prototype._replaceArrow = function($tip, delta, dimension, position) {
-      return $tip.find('.arrow').css(position, delta ? 50 * (1 - delta / dimension) + '%' : '');
+      // find arrow position to adjust
+      var $arrow = $tip.find('.arrow');
+      var startPos = parseFloat($arrow.css(position)) / dimension * 100 - 50;
+      return $arrow.css(position, delta ? startPos + (50 * (1 - delta / dimension)) + '%' : '');
     };
 
     Tour.prototype._scrollIntoView = function(step, callback) {

--- a/build/js/bootstrap-tour.js
+++ b/build/js/bootstrap-tour.js
@@ -677,7 +677,10 @@
     };
 
     Tour.prototype._replaceArrow = function($tip, delta, dimension, position) {
-      return $tip.find('.arrow').css(position, delta ? 50 * (1 - delta / dimension) + '%' : '');
+      // find arrow position to adjust
+      var $arrow = $tip.find('.arrow');
+      var startPos = parseFloat($arrow.css(position)) / dimension * 100 - 50;
+      return $arrow.css(position, delta ? startPos + (50 * (1 - delta / dimension)) + '%' : '');
     };
 
     Tour.prototype._scrollIntoView = function(step, callback) {

--- a/src/docs/assets/js/bootstrap-tour.js
+++ b/src/docs/assets/js/bootstrap-tour.js
@@ -677,7 +677,10 @@
     };
 
     Tour.prototype._replaceArrow = function($tip, delta, dimension, position) {
-      return $tip.find('.arrow').css(position, delta ? 50 * (1 - delta / dimension) + '%' : '');
+      // find arrow position to adjust
+      var $arrow = $tip.find('.arrow');
+      var startPos = parseFloat($arrow.css(position)) / dimension * 100 - 50;
+      return $arrow.css(position, delta ? startPos + (50 * (1 - delta / dimension)) + '%' : '');
     };
 
     Tour.prototype._scrollIntoView = function(step, callback) {

--- a/test/bootstrap-tour.js
+++ b/test/bootstrap-tour.js
@@ -677,7 +677,10 @@
     };
 
     Tour.prototype._replaceArrow = function($tip, delta, dimension, position) {
-      return $tip.find('.arrow').css(position, delta ? 50 * (1 - delta / dimension) + '%' : '');
+      // find arrow position to adjust
+      var $arrow = $tip.find('.arrow');
+      var startPos = parseFloat($arrow.css(position)) / dimension * 100 - 50;
+      return $arrow.css(position, delta ? startPos + (50 * (1 - delta / dimension)) + '%' : '');
     };
 
     Tour.prototype._scrollIntoView = function(step, callback) {


### PR DESCRIPTION
Position the arrow based on it’s previous positioning. Use the difference it had from the halfway (50%) point and add that the the previous calculation to properly determine it’s new position.

After results:
![image](https://cloud.githubusercontent.com/assets/1693819/19616694/01379ace-97cf-11e6-9df0-e05b53bfbd83.png)
![image](https://cloud.githubusercontent.com/assets/1693819/19616701/16c2ed08-97cf-11e6-9f29-112e17b45844.png)
