### PR TITLE
docs: Fix simple typo, conjuction -> conjunction

### DIFF
--- a/build/js/bootstrap-tour-standalone.js
+++ b/build/js/bootstrap-tour-standalone.js
@@ -1345,7 +1345,7 @@ function arrow(data, options) {
 
   //
   // extends keepTogether behavior making sure the popper and its
-  // reference have enough pixels in conjuction
+  // reference have enough pixels in conjunction
   //
 
   // top/left side
@@ -2050,7 +2050,7 @@ var modifiers = {
    * This modifier is used to move the `arrowElement` of the popper to make
    * sure it is positioned between the reference element and its popper element.
    * It will read the outer size of the `arrowElement` node to detect how many
-   * pixels of conjuction are needed.
+   * pixels of conjunction are needed.
    *
    * It has no effect if no `arrowElement` is provided.
    * @memberof modifiers


### PR DESCRIPTION
There is a small typo in build/js/bootstrap-tour-standalone.js.

Should read `conjunction` rather than `conjuction`.

